### PR TITLE
Make typescript command configurable

### DIFF
--- a/README.org
+++ b/README.org
@@ -28,6 +28,12 @@ Add ob-typescript.el to your =load-path= and require.
    ))
 #+END_SRC
 
+The default command used to run the typescript compiler is defined in [[help:org-babel-command:typescript][org-babel-command:typescript]]. You may configure this to do things like use a sandboxed version of the typescript compiler without having to install it globally
+
+#+begin_src emacs-lisp
+  (setq org-babel-command:typescript "npx -p typescript -- tsc")
+#+end_src
+
 ** Examples
 
 *** Execute with node.js

--- a/ob-typescript.el
+++ b/ob-typescript.el
@@ -57,6 +57,9 @@ specifying a var of the same value."
       (concat "[" (mapconcat #'org-babel-typescript-var-to-typescript var ", ") "]")
     (replace-regexp-in-string "\n" "\\\\n" (format "%S" var))))
 
+(defvar org-babel-command:typescript "tsc"
+  "Command run by ob-typescript to launch tsc compiler")
+
 (defun org-babel-execute:typescript (body params)
   "Execute a block of Typescript code with org-babel.  This function is
 called by `org-babel-execute-src-block'"
@@ -69,7 +72,8 @@ called by `org-babel-execute-src-block'"
                    )))
     (with-temp-file tmp-src-file (insert (org-babel-expand-body:generic
                                           body params (org-babel-variable-assignments:typescript params))))
-    (let ((results (org-babel-eval (format "tsc %s -out %s %s %s"
+    (let ((results (org-babel-eval (format "%s %s -out %s %s %s"
+                                           org-babel-command:typescript
                                            cmdline
                                            (org-babel-process-file-name tmp-out-file)
                                            (org-babel-process-file-name tmp-src-file)


### PR DESCRIPTION
This is useful so I can for example run this without a globally installed typescript by

```
(setq org-babel-command:typescript "npx -p typescript -- tsc")
```