### PR TITLE
Fix TS5101 error in ob-typescript.el

### DIFF
--- a/ob-typescript.el
+++ b/ob-typescript.el
@@ -69,7 +69,7 @@ called by `org-babel-execute-src-block'"
                    )))
     (with-temp-file tmp-src-file (insert (org-babel-expand-body:generic
                                           body params (org-babel-variable-assignments:typescript params))))
-    (let ((results (org-babel-eval (format "tsc %s -out %s %s %s"
+    (let ((results (org-babel-eval (format "tsc %s -outFile %s %s %s"
                                            cmdline
                                            (org-babel-process-file-name tmp-out-file)
                                            (org-babel-process-file-name tmp-src-file)


### PR DESCRIPTION
This PR addresses the new changes that are upcoming in Typescript by changing the `-out` option to `-outFile`.

```
: error TS5101: Option 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
: Use 'outFile' instead.
```